### PR TITLE
Log opponent records

### DIFF
--- a/slippi-stats.js
+++ b/slippi-stats.js
@@ -488,6 +488,26 @@ function printResults() {
             playtime = secondsToHMS(top_10[i].playtime) || '00:00:00'
             console.log(`| ${top_10[i].code}: ${top_10[i].wins} wins in ${top_10[i].games} games (${winrate}%) - ${playtime}`)
         }
+
+        console.log('\n------ OPPONENT RESULTS -------')
+
+        let winningRecords = 0, losingRecords = 0, tiedRecords = 0
+        for (i = 0; i < opponent_results.length; i++) {
+            const result = opponent_results[i]
+            const loses = result.games - result.wins
+            const { wins } = result
+            if (wins > loses) {
+                winningRecords++
+            } else if (loses > wins) {
+                losingRecords++
+            } else {
+                tiedRecords++
+            }
+        }
+        console.log('You have a:')
+        console.log(`Winning record against ${winningRecords} opponents`)
+        console.log(`Losing record against ${losingRecords} opponents`)
+        console.log(`Even record against ${tiedRecords} opponents`)
     }
 
     console.log('-------------------------------')

--- a/slippi-stats.js
+++ b/slippi-stats.js
@@ -505,11 +505,11 @@ function printResults() {
             }
         }
         winPercent = ((winningRecords / opponent_results.length) * 100).toFixed(2) || 0
-        console.log(`| Winning record against ${winningRecords} opponents (${winPercent})`)
+        console.log(`| Winning record against ${winningRecords} opponents (${winPercent}%)`)
         losePercent = ((losingRecords / opponent_results.length) * 100).toFixed(2) || 0
-        console.log(`| Losing record against ${losingRecords} opponents (${losePercent})`)
+        console.log(`| Losing record against ${losingRecords} opponents (${losePercent}%)`)
         evenPercent = ((evenRecords / opponent_results.length) * 100).toFixed(2) || 0
-        console.log(`| Even record against ${evenRecords} opponents (${evenPercent})`)
+        console.log(`| Even record against ${evenRecords} opponents (${evenPercent}%)`)
     }
 
     console.log('-------------------------------')

--- a/slippi-stats.js
+++ b/slippi-stats.js
@@ -489,9 +489,9 @@ function printResults() {
             console.log(`| ${top_10[i].code}: ${top_10[i].wins} wins in ${top_10[i].games} games (${winrate}%) - ${playtime}`)
         }
 
-        console.log('\n------ OPPONENT RESULTS -------')
+        console.log('------ OPPONENT RESULTS -------')
 
-        let winningRecords = 0, losingRecords = 0, tiedRecords = 0
+        let winningRecords = 0, losingRecords = 0, evenRecords = 0
         for (i = 0; i < opponent_results.length; i++) {
             const result = opponent_results[i]
             const loses = result.games - result.wins
@@ -501,13 +501,15 @@ function printResults() {
             } else if (loses > wins) {
                 losingRecords++
             } else {
-                tiedRecords++
+                evenRecords++
             }
         }
-        console.log('You have a:')
-        console.log(`Winning record against ${winningRecords} opponents`)
-        console.log(`Losing record against ${losingRecords} opponents`)
-        console.log(`Even record against ${tiedRecords} opponents`)
+        winPercent = ((winningRecords / opponent_results.length) * 100).toFixed(2) || 0
+        console.log(`| Winning record against ${winningRecords} opponents (${winPercent})`)
+        losePercent = ((losingRecords / opponent_results.length) * 100).toFixed(2) || 0
+        console.log(`| Losing record against ${losingRecords} opponents (${losePercent})`)
+        evenPercent = ((evenRecords / opponent_results.length) * 100).toFixed(2) || 0
+        console.log(`| Even record against ${evenRecords} opponents (${evenPercent})`)
     }
 
     console.log('-------------------------------')


### PR DESCRIPTION
This adds a new stat type around total opponent win/loss records. If you tend to play people you lose to for longer, that will impact your overall win/loss record, but that doesn't necessarily represent the percent of opponents you are better than. For example, here are my stats:

```
------- OVERALL RESULTS -------
| BrickLee (BRIC#563)
| 798 wins in 1538 games (51.89% win rate)
| 61:47:21 in analyzed matches. 62:05:21 including 109 skipped replays
....
-------- TOP OPPONENTS --------
| ADMI#105: 74 wins in 247 games (29.96%) - 10:05:02
| PIE#381: 25 wins in 189 games (13.23%) - 07:14:02
....
------ OPPONENT RESULTS -------
| Winning record against 224 opponents (68.09%)
| Losing record against 88 opponents (26.75%)
| Even record against 17 opponents (5.17%)
```

The 2 people I play the most are just much better than I am, so my overall win rate is fairly small. However I actually have a winning record against 68% of the people I play, which I feel more accurately represents where I fit in the unranked community. 